### PR TITLE
Delay allocation of queues and tasks until a CAN bus is actually init…

### DIFF
--- a/src/esp32_can_builtin.h
+++ b/src/esp32_can_builtin.h
@@ -44,6 +44,8 @@
 
 //#define DEBUG_SETUP
 #define NUM_FILTERS 32
+#define RX_BUFFER_SIZE	64
+#define TX_BUFFER_SIZE  16
 
 typedef struct
 {
@@ -80,6 +82,7 @@ public:
 private:
   // Pin variables
   ESP32_FILTER filters[NUM_FILTERS];
+  bool initializedResources;
 };
 
 extern QueueHandle_t callbackQueue;

--- a/src/mcp2515.h
+++ b/src/mcp2515.h
@@ -37,6 +37,9 @@
 
 //#define DEBUG_SETUP
 
+#define RX_BUFFER_SIZE	32
+#define TX_BUFFER_SIZE  16
+
 class MCP2515 : public CAN_COMMON
 {
   public:
@@ -93,6 +96,7 @@ class MCP2515 : public CAN_COMMON
   private:
 	bool _init(uint32_t baud, uint8_t freq, uint8_t sjw, bool autoBaud);
     void handleFrameDispatch(CAN_FRAME *frame, int filterHit);
+    void initializeResources();
     // Pin variables
 	uint8_t _CS;
 	uint8_t _INT;
@@ -102,6 +106,7 @@ class MCP2515 : public CAN_COMMON
 	volatile uint8_t savedFreq;
 	volatile uint8_t running; //1 if out of init code, 0 if still trying to initialize (auto baud detecting)
 	volatile bool inhibitTransactions;
+    bool initializedResources;
     // Definitions for software buffers
 };
 

--- a/src/mcp2517fd.h
+++ b/src/mcp2517fd.h
@@ -6,8 +6,8 @@
 #include <can_common.h>
 
 //#define DEBUG_SETUP
-#define RX_BUFFER_SIZE	32
-#define TX_BUFFER_SIZE	8  //there are three buffers though so (value * 3)
+#define RX_BUFFER_SIZE	64
+#define TX_BUFFER_SIZE  16  //there are three buffers though so (value * 3)
 
 #define NUM_FILTERS 32
 
@@ -80,6 +80,7 @@ class MCP2517FD : public CAN_COMMON
     void handleFrameDispatch(CAN_FRAME_FD &frame, int filterHit);
 	void handleTXFifoISR(int fifo);
 	void handleTXFifo(int fifo, CAN_FRAME_FD &newFrame);
+    void initializeResources();
 
     // Pin variables
 	uint8_t _CS;
@@ -89,6 +90,7 @@ class MCP2517FD : public CAN_COMMON
 	volatile uint32_t savedDataBaud;
 	volatile uint8_t savedFreq;
 	volatile uint8_t running; //1 if out of init code, 0 if still trying to initialize (auto baud detecting)
+    bool initializedResources; //have we set up queues and interrupts?
 	QueueHandle_t	rxQueue;
 	QueueHandle_t	txQueue[3];
 };


### PR DESCRIPTION
…ialized.

This fixes problems with early boot when you're using a lot of libraries all at once.