### PR TITLE
Remove hard-coded crystal speed in mcp2515

### DIFF
--- a/src/mcp2515.cpp
+++ b/src/mcp2515.cpp
@@ -115,7 +115,7 @@ MCP2515::MCP2515(uint8_t CS_Pin, uint8_t INT_Pin) : CAN_COMMON(6) {
   _INT = INT_Pin;
   
   savedBaud = 0;
-  savedFreq = 0;
+  savedFreq = 16;
   running = 0; 
   inhibitTransactions = false;
   initializedResources = false;

--- a/src/mcp2515.cpp
+++ b/src/mcp2515.cpp
@@ -435,17 +435,17 @@ int MCP2515::_setFilterSpecific(uint8_t mailbox, uint32_t id, uint32_t mask, boo
 
 uint32_t MCP2515::init(uint32_t ul_baudrate)
 {
-    Init(ul_baudrate, 16);
+    Init(ul_baudrate, savedFreq);
 }
 
 uint32_t MCP2515::beginAutoSpeed()
 {
-    Init(0, 16);
+    Init(0, savedFreq);
 }
 
 uint32_t MCP2515::set_baudrate(uint32_t ul_baudrate)
 {
-    Init(ul_baudrate, 16);
+    Init(ul_baudrate, savedFreq);
 }
 
 void MCP2515::setListenOnlyMode(bool state)


### PR DESCRIPTION
Calls to three functions currently contain hardcoded crystal speeds (16Mhz) rather than using the saved value.  As a result, for example, calling beginAutoSpeed() overwrites the crystal speed previously set with a call to Init.

I suspect this may have been done because users of the library may not be calling Init themselves, meaning that the crystal speed may be left unset?  If so, setting a default value for savedFreq would mean this PR is non-backward-breaking.  Happy to add that change to the PR.