### PR TITLE
Fix filter address selection for MCP2515

### DIFF
--- a/src/mcp2515.cpp
+++ b/src/mcp2515.cpp
@@ -380,7 +380,11 @@ int MCP2515::_setFilter(uint32_t id, uint32_t mask, bool extended)
 
     for (int i = 0; i < 6; i++)
     {
-        GetRXFilter(i, filterVal, isExtended);
+        if (i < 3)
+            GetRXFilter(FILTER0 + (i * 4), filterVal, isExtended);
+        else
+            GetRXFilter(FILTER3 + ((i-3) * 4), filterVal, isExtended);
+
         if (filterVal == 0 && isExtended == extended) //empty filter. Let's fill it and leave
         {
             if (i < 2)


### PR DESCRIPTION
The code for checking whether a filter was already in use was incorrect - it used the iteration count rather than the filter address.  Now fixed using the (correct) code from later in the function where the filter was set (rather than read).