### PR TITLE
Add MCP2515 receive buffer 0 rollover enable

### DIFF
--- a/src/mcp2515.cpp
+++ b/src/mcp2515.cpp
@@ -459,6 +459,29 @@ void MCP2515::setListenOnlyMode(bool state)
     else Mode(MODE_NORMAL);
 }
 
+void MCP2515::setBuffer0RolloverBUKT(bool enable) {
+    const byte oldMode = Read(CANSTAT);
+
+    if (oldMode != MODE_CONFIG) {
+        if (!Mode(MODE_CONFIG)) {
+            Serial.println("Unable to change to config mode to set BUKT");
+            return;
+        }
+    }
+
+    byte oldValue = Read(RXB0CTRL);
+
+    if (enable) {
+        Write(RXB0CTRL, oldValue | RXB0BUKT);
+    } else {
+        Write(RXB0CTRL, oldValue & ~RXB0BUKT);
+    }
+
+    if (oldMode != MODE_CONFIG) {
+        Mode(oldMode);
+    }
+}
+
 void MCP2515::enable()
 {
     Mode(MODE_NORMAL);

--- a/src/mcp2515.h
+++ b/src/mcp2515.h
@@ -90,6 +90,7 @@ class MCP2515 : public CAN_COMMON
     void GetRXFilter(uint8_t filter, uint32_t &filterVal, boolean &isExtended);
     void GetRXMask(uint8_t mask, uint32_t &filterVal);
 	void sendCallback(CAN_FRAME *frame);
+    void setBuffer0RolloverBUKT(bool enable);
 
 	void InitFilters(bool permissive);
 	void intHandler();

--- a/src/mcp2515_defs.h
+++ b/src/mcp2515_defs.h
@@ -130,6 +130,7 @@
 #define RXB0EID8        0x63
 #define RXB0EID0        0x64
 #define RXB0DLC         0x65
+#define RXB0BUKT        0x04
 #define RXB0D0          0x66
 #define RXB0D1          0x67
 #define RXB0D2          0x68


### PR DESCRIPTION
The MCP2515 has two receive buffers.  The first is the higher priority of the two,
and the chip can be configured to store the next frame in the second buffer if
the first is full and hasn't yet been read.  A function to enable/ disable this
rollover (called BUKT in the datasheet) has been added.