### PR TITLE
Remove hardcoded reference to CAN0 and CAN1 

### DIFF
--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -50,7 +50,7 @@ void CAN_WatchDog_Builtin( void *pvParameters )
             needReset = 0;
             if (CAN_cfg.speed > 0 && CAN_cfg.speed <= 1000000ul && espCan->initializedResources == true) 
             {
-                if (espCan->debuggingMode)   Serial.println("CAN0 Forced Reset!");
+                if (espCan->debuggingMode)   Serial.println("Builtin CAN Forced Reset!");
                 CAN_stop();
                 CAN_init();
             }

--- a/src/mcp2515.cpp
+++ b/src/mcp2515.cpp
@@ -73,10 +73,11 @@ void task_MCP15( void *pvParameters )
 
 void task_MCPInt15( void *pvParameters )
 {
+  MCP2515* mcpCan = (MCP2515*)pvParameters;
   while (1)
   {
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY); //wait infinitely for this task to be notified
-    CAN1.intHandler(); //not truly an interrupt handler anymore but still kind of
+    mcpCan->intHandler(); //not truly an interrupt handler anymore but still kind of
   }
 }
 


### PR DESCRIPTION
The only functional change is actually in the MCP2515.cpp file, where the hardcoded reference to CAN0 is replaced by using the pointer passed into the method.