### PR TITLE
2515 reset watchdog

### DIFF
--- a/src/mcp2515.cpp
+++ b/src/mcp2515.cpp
@@ -131,8 +131,8 @@ void MCP2515::initializeResources()
   callbackQueueM15 = xQueueCreate(16, sizeof(CAN_FRAME));
 
                             //func        desc    stack, params, priority, handle to task, core to pin to
-  xTaskCreatePinnedToCore(&task_MCP15, "CAN_RX_M15", 4096, this, 3, NULL, 0);
-  xTaskCreatePinnedToCore(&task_MCPInt15, "CAN_INT_M15", 4096, this, 10, &intDelegateTask, 0);
+  xTaskCreatePinnedToCore(&task_MCP15, "CAN_RX_M15", 4096, this, 8, NULL, 0);
+  xTaskCreatePinnedToCore(&task_MCPInt15, "CAN_INT_M15", 4096, this, 19, &intDelegateTask, 0);
 
   initializedResources = true;
 }

--- a/src/mcp2515.cpp
+++ b/src/mcp2515.cpp
@@ -36,9 +36,9 @@
 
 SPISettings mcpSPISettings(8000000, MSBFIRST, SPI_MODE0);
 
-static TaskHandle_t intDelegateTask = NULL;
-
-QueueHandle_t	callbackQueueM15;
+DRAM_ATTR TaskHandle_t intDelegateTask = NULL;
+QueueHandle_t callbackQueueM15;
+TaskHandle_t taskHandleReset = NULL;
 
 void MCP_INTHandler() {
   BaseType_t xHigherPriorityTaskWoken = pdFALSE;
@@ -79,6 +79,20 @@ void task_MCPInt15( void *pvParameters )
     ulTaskNotifyTake(pdTRUE, portMAX_DELAY); //wait infinitely for this task to be notified
     mcpCan->intHandler(); //not truly an interrupt handler anymore but still kind of
   }
+}
+
+//checks every 2 seconds to see if the chip is in error state, and reset it if so.
+void task_ResetWatcher(void *pvParameters)
+{
+    MCP2515* mcpCan = (MCP2515*)pvParameters;
+    const TickType_t xDelay = 2000 / portTICK_PERIOD_MS;
+
+    while (1) {
+        vTaskDelay(xDelay);
+        if(mcpCan->isInErrorState()) {
+            mcpCan->resetErrors();
+        }
+    }
 }
 
 void MCP2515::sendCallback(CAN_FRAME *frame)
@@ -133,6 +147,7 @@ void MCP2515::initializeResources()
                             //func        desc    stack, params, priority, handle to task, core to pin to
   xTaskCreatePinnedToCore(&task_MCP15, "CAN_RX_M15", 4096, this, 8, NULL, 0);
   xTaskCreatePinnedToCore(&task_MCPInt15, "CAN_INT_M15", 4096, this, 19, &intDelegateTask, 0);
+  xTaskCreatePinnedToCore(&task_ResetWatcher, "CAN_RSTWATCH_M15", 1536, this, 7, &taskHandleReset, 0);
 
   initializedResources = true;
 }
@@ -999,4 +1014,14 @@ void MCP2515::handleFrameDispatch(CAN_FRAME *frame, int filterHit)
 	} 
 	//if none of the callback types caught this frame then queue it in the buffer
   xQueueSendFromISR(rxQueue, frame, NULL);
+}
+
+bool MCP2515::isInErrorState() {
+    byte errorRegisterContents = Read(EFLG);
+    return (errorRegisterContents & EFLG_ERRORMASK);
+}
+
+void MCP2515::resetErrors() {
+    Write(CANINTF, 0);     // acknowledge any interrupts
+    Write(EFLG, 0);        // clear the error flags
 }

--- a/src/mcp2515.h
+++ b/src/mcp2515.h
@@ -91,6 +91,8 @@ class MCP2515 : public CAN_COMMON
     void GetRXMask(uint8_t mask, uint32_t &filterVal);
 	void sendCallback(CAN_FRAME *frame);
     void setBuffer0RolloverBUKT(bool enable);
+    bool isInErrorState();
+    void resetErrors();
 
 	void InitFilters(bool permissive);
 	void intHandler();

--- a/src/mcp2515_defs.h
+++ b/src/mcp2515_defs.h
@@ -60,6 +60,8 @@
 #define ERRIF			0x20
 #define WAKIF			0x40
 #define MERRF			0x80
+// EFLG
+#define EFLG_ERRORMASK  0xF8
 
 // Configuration Registers
 #define CANSTAT         0x0E


### PR DESCRIPTION
Have combined two changes here - happy to discuss.  Both changes are to the MCP2515 code only.
* The first aligns the priorities of the MCP2515 threads to match the priorities in the 2517 code and the internal controller code.
* The second adds a watchdog thread that runs every 2 seconds to check the chip for an error state and reset it if needed.  This brings the MCP2515 chip code up to match the 2517 code.  
