### PR TITLE
Add TWAI operation mode

### DIFF
--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -80,10 +80,6 @@ void ESP32CAN::setCANPins(gpio_num_t rxPin, gpio_num_t txPin)
     twai_general_cfg.tx_io = txPin;
 }
 
-void ESP32CAN::setOperationMode(twai_mode_t mode) {
-    twai_general_cfg.mode = mode;
-}
-
 void CAN_WatchDog_Builtin( void *pvParameters )
 {
     ESP32CAN* espCan = (ESP32CAN*)pvParameters;
@@ -331,6 +327,13 @@ void ESP32CAN::setListenOnlyMode(bool state)
 {
     disable();
     twai_general_cfg.mode = state?TWAI_MODE_LISTEN_ONLY:TWAI_MODE_NORMAL;
+    enable();
+}
+
+void ESP32CAN::setNoACKMode(bool state)
+{
+    disable();
+    twai_general_cfg.mode = state?TWAI_MODE_NO_ACK:TWAI_MODE_NORMAL;
     enable();
 }
 

--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -80,6 +80,10 @@ void ESP32CAN::setCANPins(gpio_num_t rxPin, gpio_num_t txPin)
     twai_general_cfg.tx_io = txPin;
 }
 
+void ESP32CAN::setOperationMode(twai_mode_t mode) {
+    twai_general_cfg.mode = mode;
+}
+
 void CAN_WatchDog_Builtin( void *pvParameters )
 {
     ESP32CAN* espCan = (ESP32CAN*)pvParameters;

--- a/src/esp32_can_builtin.h
+++ b/src/esp32_can_builtin.h
@@ -76,6 +76,7 @@ public:
   uint32_t beginAutoSpeed();
   uint32_t set_baudrate(uint32_t ul_baudrate);
   void setListenOnlyMode(bool state);
+  void setNoACKMode(bool state);
   void enable();
   void disable();
   bool sendFrame(CAN_FRAME& txFrame);
@@ -88,7 +89,6 @@ public:
   void sendCallback(CAN_FRAME *frame);
 
   void setCANPins(gpio_num_t rxPin, gpio_num_t txPin);
-  void setOperationMode(twai_mode_t mode);
 
   friend void CAN_WatchDog_Builtin( void *pvParameters );
   friend void task_LowLevelRX(void *pvParameters);

--- a/src/esp32_can_builtin.h
+++ b/src/esp32_can_builtin.h
@@ -88,6 +88,7 @@ public:
   void sendCallback(CAN_FRAME *frame);
 
   void setCANPins(gpio_num_t rxPin, gpio_num_t txPin);
+  void setOperationMode(twai_mode_t mode);
 
   friend void CAN_WatchDog_Builtin( void *pvParameters );
   friend void task_LowLevelRX(void *pvParameters);


### PR DESCRIPTION
This PR allows you to set the operation mode of the TWAI driver to `NO_ACK` the same way you can set it to listen only:

`CAN0.setNoACKMode(true);`