### PR TITLE
Add support for single Core ESP32 / multiple TWAI controllers

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32_CAN
-version=0.2.6
+version=0.3.0
 author=Collin Kidder
 maintainer=Collin Kidder <kidderc@gmail.com>
 sentence=Library to facilitate CAN functionality with the on-chip CAN hardware as well as the MCP2517FD

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP32_CAN
-version=0.2.5
+version=0.2.6
 author=Collin Kidder
 maintainer=Collin Kidder <kidderc@gmail.com>
 sentence=Library to facilitate CAN functionality with the on-chip CAN hardware as well as the MCP2517FD

--- a/src/esp32_can.cpp
+++ b/src/esp32_can.cpp
@@ -10,5 +10,9 @@ ESP32CAN __attribute__((weak)) CAN0(GPIO_NUM_16, GPIO_NUM_17) ;
 
 //Select and uncomment the proper module you've got connected via SPI
             //CS, INT
+#if SOC_TWAI_CONTROLLER_NUM == 2
+ESP32CAN __attribute__((weak)) CAN1(GPIO_NUM_18, GPIO_NUM_19) ;
+#elif
 MCP2517FD __attribute__((weak)) CAN1(5, 27) ;
+#else
 //MCP2515 __attribute__((weak)) CAN1(5, 27) ;

--- a/src/esp32_can.cpp
+++ b/src/esp32_can.cpp
@@ -6,10 +6,10 @@
 
 //Set these to the proper pin numbers for you board. Set by default to correct for EVTV ESP32-Due
              //rxpin       txpin
-ESP32CAN __attribute__((weak)) CAN0(GPIO_NUM_16, GPIO_NUM_17) ;
+ESP32CAN __attribute__((weak)) CAN0(GPIO_NUM_16, GPIO_NUM_17, 0) ;
 
 #if SOC_TWAI_CONTROLLER_NUM == 2
-ESP32CAN __attribute__((weak)) CAN1(GPIO_NUM_18, GPIO_NUM_19);
+ESP32CAN __attribute__((weak)) CAN1(GPIO_NUM_18, GPIO_NUM_19, 1);
 
 #if defined(HAS_EXTERNAL_CAN_CONTROLLER)
 //Select and uncomment the proper module you've got connected via SPI

--- a/src/esp32_can.cpp
+++ b/src/esp32_can.cpp
@@ -11,14 +11,17 @@ ESP32CAN __attribute__((weak)) CAN0(GPIO_NUM_16, GPIO_NUM_17, 0) ;
 #if SOC_TWAI_CONTROLLER_NUM == 2 and ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
 ESP32CAN __attribute__((weak)) CAN1(GPIO_NUM_18, GPIO_NUM_19, 1);
 
-#if defined(HAS_EXTERNAL_CAN_CONTROLLER)
+#if defined(USES_MCP2517FD)
 //CS, INT
 MCP2517FD __attribute__((weak)) CAN2(5, 27) ;
+#elif defined(USES_MCP2515)
+MCP2515 __attribute__((weak)) CAN2(5, 27) ;
 #endif
 
-#elif defined (HAS_EXTERNAL_CAN_CONTROLLER)
+#elif defined (USES_MCP2517FD)
 //Select and uncomment the proper module you've got connected via SPI
 //CS, INT
 MCP2517FD __attribute__((weak)) CAN1(5, 27) ;
-//MCP2515 __attribute__((weak)) CAN1(5, 27) ;
+#elif defined (USES_MCP2515)
+MCP2515 __attribute__((weak)) CAN1(5, 27) ;
 #endif

--- a/src/esp32_can.cpp
+++ b/src/esp32_can.cpp
@@ -12,10 +12,8 @@ ESP32CAN __attribute__((weak)) CAN0(GPIO_NUM_16, GPIO_NUM_17, 0) ;
 ESP32CAN __attribute__((weak)) CAN1(GPIO_NUM_18, GPIO_NUM_19, 1);
 
 #if defined(HAS_EXTERNAL_CAN_CONTROLLER)
-//Select and uncomment the proper module you've got connected via SPI
 //CS, INT
-MCP2517FD __attribute__((weak)) CAN1(5, 27) ;
-//MCP2515 __attribute__((weak)) CAN1(5, 27) ;
+MCP2517FD __attribute__((weak)) CAN2(5, 27) ;
 #endif
 
 #elif defined (HAS_EXTERNAL_CAN_CONTROLLER)

--- a/src/esp32_can.cpp
+++ b/src/esp32_can.cpp
@@ -8,7 +8,7 @@
              //rxpin       txpin
 ESP32CAN __attribute__((weak)) CAN0(GPIO_NUM_16, GPIO_NUM_17, 0) ;
 
-#if SOC_TWAI_CONTROLLER_NUM == 2
+#if SOC_TWAI_CONTROLLER_NUM == 2 and ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
 ESP32CAN __attribute__((weak)) CAN1(GPIO_NUM_18, GPIO_NUM_19, 1);
 
 #if defined(HAS_EXTERNAL_CAN_CONTROLLER)

--- a/src/esp32_can.cpp
+++ b/src/esp32_can.cpp
@@ -24,9 +24,3 @@ MCP2517FD __attribute__((weak)) CAN1(5, 27) ;
 MCP2517FD __attribute__((weak)) CAN1(5, 27) ;
 //MCP2515 __attribute__((weak)) CAN1(5, 27) ;
 #endif
-
-#if SOC_TWAI_CONTROLLER_NUM == 2
-ESP32CAN __attribute__((weak)) CAN1(GPIO_NUM_18, GPIO_NUM_19);
-#else
-MCP2517FD __attribute__((weak)) CAN1(5, 27) ;
-#endif

--- a/src/esp32_can.cpp
+++ b/src/esp32_can.cpp
@@ -12,7 +12,7 @@ ESP32CAN __attribute__((weak)) CAN0(GPIO_NUM_16, GPIO_NUM_17) ;
             //CS, INT
 #if SOC_TWAI_CONTROLLER_NUM == 2
 ESP32CAN __attribute__((weak)) CAN1(GPIO_NUM_18, GPIO_NUM_19) ;
-#elif
-MCP2517FD __attribute__((weak)) CAN1(5, 27) ;
 #else
+MCP2517FD __attribute__((weak)) CAN1(5, 27) ;
+#endif
 //MCP2515 __attribute__((weak)) CAN1(5, 27) ;

--- a/src/esp32_can.cpp
+++ b/src/esp32_can.cpp
@@ -8,11 +8,25 @@
              //rxpin       txpin
 ESP32CAN __attribute__((weak)) CAN0(GPIO_NUM_16, GPIO_NUM_17) ;
 
-//Select and uncomment the proper module you've got connected via SPI
-            //CS, INT
 #if SOC_TWAI_CONTROLLER_NUM == 2
-ESP32CAN __attribute__((weak)) CAN1(GPIO_NUM_18, GPIO_NUM_19) ;
+ESP32CAN __attribute__((weak)) CAN1(GPIO_NUM_18, GPIO_NUM_19);
+
+#if defined(HAS_EXTERNAL_CAN_CONTROLLER)
+//Select and uncomment the proper module you've got connected via SPI
+//CS, INT
+MCP2517FD __attribute__((weak)) CAN1(5, 27) ;
+//MCP2515 __attribute__((weak)) CAN1(5, 27) ;
+#endif
+
+#elif defined (HAS_EXTERNAL_CAN_CONTROLLER)
+//Select and uncomment the proper module you've got connected via SPI
+//CS, INT
+MCP2517FD __attribute__((weak)) CAN1(5, 27) ;
+//MCP2515 __attribute__((weak)) CAN1(5, 27) ;
+#endif
+
+#if SOC_TWAI_CONTROLLER_NUM == 2
+ESP32CAN __attribute__((weak)) CAN1(GPIO_NUM_18, GPIO_NUM_19);
 #else
 MCP2517FD __attribute__((weak)) CAN1(5, 27) ;
 #endif
-//MCP2515 __attribute__((weak)) CAN1(5, 27) ;

--- a/src/esp32_can.h
+++ b/src/esp32_can.h
@@ -1,11 +1,14 @@
 #include "esp32_can_builtin.h"
 
 // add the following define into your code if you have an MCP2517FD or MCP2515 connected to the SPI bus
-// #define HAS_EXTERNAL_CAN_CONTROLLER
+// #define USES_MCP2515
+// or
+// #define USES_MCP2517FD
 
-#if defined(HAS_EXTERNAL_CAN_CONTROLLER)
-#include "mcp2517fd.h"  //uncomment if you've got a mcp2517fd attached to spi
-//#include "mcp2515.h" //uncomment if you've got a MCP2515 attached to SPI
+#if defined(USES_MCP2517FD)
+#include "mcp2517fd.h"
+#elif defined(USES_MCP2515)
+#include "mcp2515.h"
 #endif
 
 extern ESP32CAN CAN0;
@@ -14,14 +17,16 @@ extern ESP32CAN CAN0;
 #if SOC_TWAI_CONTROLLER_NUM == 2 and ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
 extern ESP32CAN CAN1;
 
-#if defined(HAS_EXTERNAL_CAN_CONTROLLER)
+#if defined(USES_MCP2517FD)
 extern MCP2517FD CAN2;
-// extern MCP2515 CAN2;
+#elif defined(USES_MCP2515)
+extern MCP2515 CAN2;
 #endif
 
-#elif defined (HAS_EXTERNAL_CAN_CONTROLLER)
+#elif defined (USES_MCP2517FD)
 extern MCP2517FD CAN1;
-//extern MCP2515 CAN1;
+#elif defined (USES_MCP2515)
+extern MCP2515 CAN1;
 #endif
 
 extern volatile uint32_t biIntsCounter;
@@ -29,10 +34,10 @@ extern volatile uint32_t biReadFrames;
 
 #define Can0 CAN0
 
-#if (SOC_TWAI_CONTROLLER_NUM == 2 and ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)) or defined (HAS_EXTERNAL_CAN_CONTROLLER)
+#if (SOC_TWAI_CONTROLLER_NUM == 2 and ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)) or defined (USES_MCP2517FD) or defined (USES_MCP2515)
 #define Can1 CAN1
 #endif
 
-#if (SOC_TWAI_CONTROLLER_NUM == 2 and ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)) and defined (HAS_EXTERNAL_CAN_CONTROLLER)
+#if (SOC_TWAI_CONTROLLER_NUM == 2 and ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)) and (defined (USES_MCP2517FD) or defined (USES_MCP2515))
 #define Can2 CAN2
 #endif

--- a/src/esp32_can.h
+++ b/src/esp32_can.h
@@ -11,7 +11,7 @@
 extern ESP32CAN CAN0;
 //Select which external chip you've got connected
 
-#if SOC_TWAI_CONTROLLER_NUM == 2
+#if SOC_TWAI_CONTROLLER_NUM == 2 and ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
 extern ESP32CAN CAN1;
 
 #if defined(HAS_EXTERNAL_CAN_CONTROLLER)
@@ -29,10 +29,10 @@ extern volatile uint32_t biReadFrames;
 
 #define Can0 CAN0
 
-#if (SOC_TWAI_CONTROLLER_NUM == 2) or defined (HAS_EXTERNAL_CAN_CONTROLLER)
+#if (SOC_TWAI_CONTROLLER_NUM == 2 and ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)) or defined (HAS_EXTERNAL_CAN_CONTROLLER)
 #define Can1 CAN1
 #endif
 
-#if (SOC_TWAI_CONTROLLER_NUM == 2) and defined (HAS_EXTERNAL_CAN_CONTROLLER)
+#if (SOC_TWAI_CONTROLLER_NUM == 2 and ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)) and defined (HAS_EXTERNAL_CAN_CONTROLLER)
 #define Can2 CAN2
 #endif

--- a/src/esp32_can.h
+++ b/src/esp32_can.h
@@ -1,13 +1,24 @@
 #include "esp32_can_builtin.h"
+
+// #define HAS_EXTERNAL_TWAI_CONTROLLER
+
+#if defined(USES_EXTERNAL_TWAI_CONTROLLER)
 #include "mcp2517fd.h"  //uncomment if you've got a mcp2517fd attached to spi
 //#include "mcp2515.h" //uncomment if you've got a MCP2515 attached to SPI
+#endif
 
 extern ESP32CAN CAN0;
 //Select which external chip you've got connected
 
 #if SOC_TWAI_CONTROLLER_NUM == 2
 extern ESP32CAN CAN1;
-#else
+
+#if defined(USES_EXTERNAL_TWAI_CONTROLLER)
+extern MCP2517FD CAN2;
+// extern MCP2515 CAN2;
+#endif
+
+#elif defined (USES_EXTERNAL_TWAI_CONTROLLER)
 extern MCP2517FD CAN1;
 //extern MCP2515 CAN1;
 #endif
@@ -16,4 +27,11 @@ extern volatile uint32_t biIntsCounter;
 extern volatile uint32_t biReadFrames;
 
 #define Can0 CAN0
+
+#if (SOC_TWAI_CONTROLLER_NUM == 2) or defined (USES_EXTERNAL_TWAI_CONTROLLER)
 #define Can1 CAN1
+#endif
+
+#if (SOC_TWAI_CONTROLLER_NUM == 2) and defined (USES_EXTERNAL_TWAI_CONTROLLER)
+#define Can2 CAN2
+#endif

--- a/src/esp32_can.h
+++ b/src/esp32_can.h
@@ -1,9 +1,9 @@
 #include "esp32_can_builtin.h"
 
 // add the following define into your code if you have an MCP2517FD or MCP2515 connected to the SPI bus
-// #define HAS_EXTERNAL_TWAI_CONTROLLER
+// #define HAS_EXTERNAL_CAN_CONTROLLER
 
-#if defined(HAS_EXTERNAL_TWAI_CONTROLLER)
+#if defined(HAS_EXTERNAL_CAN_CONTROLLER)
 #include "mcp2517fd.h"  //uncomment if you've got a mcp2517fd attached to spi
 //#include "mcp2515.h" //uncomment if you've got a MCP2515 attached to SPI
 #endif
@@ -14,12 +14,12 @@ extern ESP32CAN CAN0;
 #if SOC_TWAI_CONTROLLER_NUM == 2
 extern ESP32CAN CAN1;
 
-#if defined(HAS_EXTERNAL_TWAI_CONTROLLER)
+#if defined(HAS_EXTERNAL_CAN_CONTROLLER)
 extern MCP2517FD CAN2;
 // extern MCP2515 CAN2;
 #endif
 
-#elif defined (HAS_EXTERNAL_TWAI_CONTROLLER)
+#elif defined (HAS_EXTERNAL_CAN_CONTROLLER)
 extern MCP2517FD CAN1;
 //extern MCP2515 CAN1;
 #endif
@@ -29,10 +29,10 @@ extern volatile uint32_t biReadFrames;
 
 #define Can0 CAN0
 
-#if (SOC_TWAI_CONTROLLER_NUM == 2) or defined (HAS_EXTERNAL_TWAI_CONTROLLER)
+#if (SOC_TWAI_CONTROLLER_NUM == 2) or defined (HAS_EXTERNAL_CAN_CONTROLLER)
 #define Can1 CAN1
 #endif
 
-#if (SOC_TWAI_CONTROLLER_NUM == 2) and defined (HAS_EXTERNAL_TWAI_CONTROLLER)
+#if (SOC_TWAI_CONTROLLER_NUM == 2) and defined (HAS_EXTERNAL_CAN_CONTROLLER)
 #define Can2 CAN2
 #endif

--- a/src/esp32_can.h
+++ b/src/esp32_can.h
@@ -4,8 +4,13 @@
 
 extern ESP32CAN CAN0;
 //Select which external chip you've got connected
+
+#if SOC_TWAI_CONTROLLER_NUM == 2
+extern ESP32CAN CAN1;
+#else
 extern MCP2517FD CAN1;
 //extern MCP2515 CAN1;
+#endif
 
 extern volatile uint32_t biIntsCounter;
 extern volatile uint32_t biReadFrames;

--- a/src/esp32_can.h
+++ b/src/esp32_can.h
@@ -11,6 +11,11 @@
 #include "mcp2515.h"
 #endif
 
+// only one of these can be defined
+#if defined(USES_MCP2517FD) and defined(USES_MCP2515)
+#error "Only one of USES_MCP2517FD or USES_MCP2515 can be defined"
+#endif
+
 extern ESP32CAN CAN0;
 //Select which external chip you've got connected
 

--- a/src/esp32_can.h
+++ b/src/esp32_can.h
@@ -1,8 +1,9 @@
 #include "esp32_can_builtin.h"
 
+// add the following define into your code if you have an MCP2517FD or MCP2515 connected to the SPI bus
 // #define HAS_EXTERNAL_TWAI_CONTROLLER
 
-#if defined(USES_EXTERNAL_TWAI_CONTROLLER)
+#if defined(HAS_EXTERNAL_TWAI_CONTROLLER)
 #include "mcp2517fd.h"  //uncomment if you've got a mcp2517fd attached to spi
 //#include "mcp2515.h" //uncomment if you've got a MCP2515 attached to SPI
 #endif
@@ -13,12 +14,12 @@ extern ESP32CAN CAN0;
 #if SOC_TWAI_CONTROLLER_NUM == 2
 extern ESP32CAN CAN1;
 
-#if defined(USES_EXTERNAL_TWAI_CONTROLLER)
+#if defined(HAS_EXTERNAL_TWAI_CONTROLLER)
 extern MCP2517FD CAN2;
 // extern MCP2515 CAN2;
 #endif
 
-#elif defined (USES_EXTERNAL_TWAI_CONTROLLER)
+#elif defined (HAS_EXTERNAL_TWAI_CONTROLLER)
 extern MCP2517FD CAN1;
 //extern MCP2515 CAN1;
 #endif
@@ -28,10 +29,10 @@ extern volatile uint32_t biReadFrames;
 
 #define Can0 CAN0
 
-#if (SOC_TWAI_CONTROLLER_NUM == 2) or defined (USES_EXTERNAL_TWAI_CONTROLLER)
+#if (SOC_TWAI_CONTROLLER_NUM == 2) or defined (HAS_EXTERNAL_TWAI_CONTROLLER)
 #define Can1 CAN1
 #endif
 
-#if (SOC_TWAI_CONTROLLER_NUM == 2) and defined (USES_EXTERNAL_TWAI_CONTROLLER)
+#if (SOC_TWAI_CONTROLLER_NUM == 2) and defined (HAS_EXTERNAL_TWAI_CONTROLLER)
 #define Can2 CAN2
 #endif

--- a/src/esp32_can.h
+++ b/src/esp32_can.h
@@ -19,6 +19,12 @@
 extern ESP32CAN CAN0;
 //Select which external chip you've got connected
 
+#if not defined(USES_MCP2517FD) and not defined(USES_MCP2515) and ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 2, 0) and not SOC_TWAI_CONTROLLER_NUM == 2
+#error "You must define either USES_MCP2517FD or USES_MCP2515"
+#define USES_MCP2515
+// #define USES_MCP2517FD
+#endif
+
 #if SOC_TWAI_CONTROLLER_NUM == 2 and ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
 extern ESP32CAN CAN1;
 

--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -54,7 +54,7 @@ ESP32CAN::ESP32CAN(gpio_num_t rxPin, gpio_num_t txPin, uint8_t busNumber) : CAN_
     rxBufferSize = BI_RX_BUFFER_SIZE;
     
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
-    bus_handle.controller_id = busNumber;
+    twai_general_cfg.controller_id = busNumber;
 #endif
 }
 
@@ -370,7 +370,7 @@ void ESP32CAN::setListenOnlyMode(bool state)
 void ESP32CAN::enable()
 {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
-    if (twai_driver_install_v2(&g_config, &t_config, &f_config, &bus_handle) == ESP_OK) {
+    if (twai_driver_install_v2(&twai_general_cfg, &twai_speed_cfg, &twai_filters_cfg, &bus_handle) == ESP_OK) {
         printf("Driver installed\n");
     } else {
         printf("Failed to install driver\n");

--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -249,9 +249,9 @@ void ESP32CAN::_init()
 
     if (!CAN_WatchDog_Builtin_handler) {
 #if defined(CONFIG_FREERTOS_UNICORE)
-        xTaskCreate(&CAN_WatchDog_Builtin, "CAN_WD_BI", 2048, this, 10, &CAN_WatchDog_Builtin_handler);
+        xTaskCreate(&CAN_WatchDog_Builtin, "CAN_WD_BI_CAN" + twai_general_cfg.controller_id, 2048, this, 10, &CAN_WatchDog_Builtin_handler);
 #else
-        xTaskCreatePinnedToCore(&CAN_WatchDog_Builtin, "CAN_WD_BI", 2048, this, 10, &CAN_WatchDog_Builtin_handler, 1);
+        xTaskCreatePinnedToCore(&CAN_WatchDog_Builtin, "CAN_WD_BI_CAN" + twai_general_cfg.controller_id, 2048, this, 10, &CAN_WatchDog_Builtin_handler, 1);
 #endif
     }
     if (debuggingMode) Serial.println("_init done");
@@ -557,7 +557,7 @@ uint32_t ESP32CAN::get_rx_buff(CAN_FRAME &msg)
 {
     CAN_FRAME frame;
     //receive next CAN frame from queue
-    if(xQueueReceive(rx_queue,&frame, 0) == pdTRUE)
+    if(xQueueReceive(rx_queue, &frame, 0) == pdTRUE)
     {
         msg = frame; //do a copy in the case that the receive worked
         return true;

--- a/src/esp32_can_builtin.h
+++ b/src/esp32_can_builtin.h
@@ -65,7 +65,12 @@ typedef struct
 class ESP32CAN : public CAN_COMMON
 {
 public:
-  ESP32CAN(gpio_num_t rxPin, gpio_num_t txPin);
+  ESP32CAN(gpio_num_t rxPin, gpio_num_t txPin, uint8_t busNumber = 0) {
+  #if SOC_TWAI_CONTROLLER_NUM == 2
+    busHandle.controller_id = busNumber;
+  #endif
+  }
+
   ESP32CAN();
 
   //block of functions which must be overriden from CAN_COMMON to implement functionality for this hardware
@@ -91,6 +96,10 @@ public:
 
   friend void CAN_WatchDog_Builtin( void *pvParameters );
   friend void task_LowLevelRX(void *pvParameters);
+
+  #if SOC_TWAI_CONTROLLER_NUM == 2
+  twai_handle_t bus_handle;
+  #endif
 
 protected:
   bool initializedResources;

--- a/src/esp32_can_builtin.h
+++ b/src/esp32_can_builtin.h
@@ -41,6 +41,8 @@
 #include "esp_system.h"
 #include "esp_adc_cal.h"
 #include "driver/twai.h"
+#include <string.h>
+#include <sstream>
 
 //#define DEBUG_SETUP
 #define BI_NUM_FILTERS 32
@@ -100,11 +102,25 @@ public:
 protected:
   bool readyForTraffic;
   int cyclesSinceTraffic;
+                                                                      //tx,         rx,           mode
+  twai_general_config_t twai_general_cfg = TWAI_GENERAL_CONFIG_DEFAULT(GPIO_NUM_17, GPIO_NUM_16, TWAI_MODE_NORMAL);
+  twai_timing_config_t twai_speed_cfg = TWAI_TIMING_CONFIG_500KBITS();
+  twai_filter_config_t twai_filters_cfg = TWAI_FILTER_CONFIG_ACCEPT_ALL();
+
+  QueueHandle_t callbackQueue;
+  QueueHandle_t rx_queue;
+
+  TaskHandle_t CAN_WatchDog_Builtin_handler = NULL;
+  TaskHandle_t task_CAN_handler = NULL;
+  TaskHandle_t task_LowLevelRX_handler = NULL;
 
 private:
   // Pin variables
   ESP32_FILTER filters[BI_NUM_FILTERS];
   int rxBufferSize;
+
+  static void task_CAN(void *pvParameters);
+  static void task_LowLevelRX(void *pvParameters);
 };
 
 extern QueueHandle_t callbackQueue;

--- a/src/esp32_can_builtin.h
+++ b/src/esp32_can_builtin.h
@@ -92,11 +92,10 @@ public:
 
   void setCANPins(gpio_num_t rxPin, gpio_num_t txPin);
 
-  friend void CAN_WatchDog_Builtin( void *pvParameters );
-  friend void task_LowLevelRX(void *pvParameters);
+  static void CAN_WatchDog_Builtin( void *pvParameters );
 
   #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
-  twai_handle_t bus_handle;
+    twai_handle_t bus_handle;
   #endif
 
 protected:

--- a/src/esp32_can_builtin.h
+++ b/src/esp32_can_builtin.h
@@ -65,12 +65,7 @@ typedef struct
 class ESP32CAN : public CAN_COMMON
 {
 public:
-  ESP32CAN(gpio_num_t rxPin, gpio_num_t txPin, uint8_t busNumber = 0) {
-  #if SOC_TWAI_CONTROLLER_NUM == 2
-    busHandle.controller_id = busNumber;
-  #endif
-  }
-
+  ESP32CAN(gpio_num_t rxPin, gpio_num_t txPin, uint8_t busNumber = 0);
   ESP32CAN();
 
   //block of functions which must be overriden from CAN_COMMON to implement functionality for this hardware
@@ -97,7 +92,7 @@ public:
   friend void CAN_WatchDog_Builtin( void *pvParameters );
   friend void task_LowLevelRX(void *pvParameters);
 
-  #if SOC_TWAI_CONTROLLER_NUM == 2
+  #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
   twai_handle_t bus_handle;
   #endif
 

--- a/src/mcp2515.cpp
+++ b/src/mcp2515.cpp
@@ -131,8 +131,13 @@ void MCP2515::initializeResources()
   callbackQueueM15 = xQueueCreate(16, sizeof(CAN_FRAME));
 
                             //func        desc    stack, params, priority, handle to task, core to pin to
+#if defined(CONFIG_FREERTOS_UNICORE)
+  xTaskCreate(&task_MCP15, "CAN_RX_M15", 4096, this, 3, NULL);
+  xTaskCreate(&task_MCPInt15, "CAN_INT_M15", 4096, this, 10, NULL);
+#else
   xTaskCreatePinnedToCore(&task_MCP15, "CAN_RX_M15", 4096, this, 3, NULL, 0);
   xTaskCreatePinnedToCore(&task_MCPInt15, "CAN_INT_M15", 4096, this, 10, &intDelegateTask, 0);
+#endif
 
   initializedResources = true;
 }

--- a/src/mcp2515.cpp
+++ b/src/mcp2515.cpp
@@ -28,6 +28,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#ifdef MCP2515_h
+
 #include "Arduino.h"
 #include "SPI.h"
 #include "mcp2515.h"
@@ -1008,3 +1010,5 @@ void MCP2515::handleFrameDispatch(CAN_FRAME *frame, int filterHit)
 	//if none of the callback types caught this frame then queue it in the buffer
   xQueueSendFromISR(rxQueue, frame, NULL);
 }
+
+#endif

--- a/src/mcp2517fd.cpp
+++ b/src/mcp2517fd.cpp
@@ -225,9 +225,15 @@ void MCP2517FD::initializeResources()
 
                            //func        desc    stack, params, priority, handle to task, which core to pin to
     //Tasks take up the stack you allocate here in bytes plus 388 bytes overhead            
+#if defined(CONFIG_FREERTOS_UNICORE)
+    xTaskCreate(&task_MCPCAN, "CAN_FD_CALLBACK", 6144, this, 8, &taskHandleMCPCAN);
+    xTaskCreate(&task_MCPIntFD, "CAN_FD_INT", 4096, this, 19, &intTaskFD);
+    xTaskCreate(&task_ResetWatcher, "CAN_RSTWATCH", 4096, this, 7, &taskHandleReset);
+#else
     xTaskCreatePinnedToCore(&task_MCPCAN, "CAN_FD_CALLBACK", 6144, this, 8, &taskHandleMCPCAN, 0);
     xTaskCreatePinnedToCore(&task_MCPIntFD, "CAN_FD_INT", 4096, this, 19, &intTaskFD, 0);
     xTaskCreatePinnedToCore(&task_ResetWatcher, "CAN_RSTWATCH", 4096, this, 7, &taskHandleReset, 0);
+#endif
     if (debuggingMode) Serial.println("Done with resource init");
 
     initializedResources = true;

--- a/src/mcp2517fd.cpp
+++ b/src/mcp2517fd.cpp
@@ -1,3 +1,5 @@
+#if MCP2517_h
+
 #include "Arduino.h"
 #include <SPI.h>
 #include "mcp2517fd.h"
@@ -1653,3 +1655,5 @@ void MCP2517FD::handleFrameDispatch(CAN_FRAME &frame, int filterHit)
     //if none of the callback types caught this frame then queue it in the buffer
     xQueueSend(rxQueue, &frame, 0);
 }
+
+#endif

--- a/src/mcp2517fd.h
+++ b/src/mcp2517fd.h
@@ -124,6 +124,4 @@ class MCP2517FD : public CAN_COMMON
     uint32_t cachedDiag1;
 };
 
-extern MCP2517FD CAN1;
-
 #endif


### PR DESCRIPTION
## Changes

- Runs `xTaskCreate` instead of `xTaskCreatePinnedToCore` if used on a device with `CONFIG_FREERTOS_UNICORE` enabled (e.g. on single core ESP32s)
- Uses a secondary internal TWAI controller if `SOC_TWAI_CONTROLLER_NUM = 2` (like on the ESP32 C6 with two CAN controllers) and IDF version >= 5.2 (which introduces the v2 TWAI API)
- Adds a preprocessor defines `USES_MCP2515` and `USES_MCP2517FD` that a user can set before including `esp32_can.h` to enable support for an MCP2515 / MCP2517FD controller. If `SOC_TWAI_CONTROLLER_NUM = 2` and IDF version >= 5.2, the MCP device shows up as `CAN2` (and `CAN1` otherwise)
- Makes tasks and queues instance specific so that they can be spawned up for each instance of built-in CAN
- Adds a delay when `CONFIG_FREERTOS_UNICORE` enabled so that `task_CAN` doesn't resource starve the processor

### Example using an MCP2517FD external controller
```c++
#define USES_MCP2517FD
#include esp32_can.h
```