### PR TITLE
Fix wrong API usage in disable() and beginAutoSpeed()

### DIFF
--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -582,6 +582,7 @@ bool ESP32CAN::sendFrame(CAN_FRAME& txFrame)
     __TX_frame.extd = txFrame.extended;
     __TX_frame.self = 0;
     __TX_frame.ss = 0;
+    __TX_frame.dlc_non_comp = 0;
     for (int i = 0; i < 8; i++) __TX_frame.data[i] = txFrame.data.byte[i];
 
     //don't wait long if the queue was full. The end user code shouldn't be sending faster

--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -580,6 +580,8 @@ bool ESP32CAN::sendFrame(CAN_FRAME& txFrame)
     __TX_frame.data_length_code = txFrame.length;
     __TX_frame.rtr = txFrame.rtr;
     __TX_frame.extd = txFrame.extended;
+    __TX_frame.self = 0;
+    __TX_frame.ss = 0;
     for (int i = 0; i < 8; i++) __TX_frame.data[i] = txFrame.data.byte[i];
 
     //don't wait long if the queue was full. The end user code shouldn't be sending faster


### PR DESCRIPTION
Hello,
we are using your CAN library in an automotive project on the ESP32-C6 where we have both CAN busses in use. 
Thank you for restructuring your library, especially removing the static init of CAN busses and the MCP2517 stuff. 
But we still have a crash when using your lib in our scenario.
This is the fix for it.
Feel free to contact us, maybe also for further collaboration.