### PR TITLE
Fix slow frame handling

### DIFF
--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -255,6 +255,10 @@ void ESP32CAN::_init()
         filters[i].configured = false;
     }
 
+    ESP_LOGI(TAG, "Creating queues");
+    callbackQueue = xQueueCreate(16, sizeof(CAN_FRAME));
+    rx_queue = xQueueCreate(rxBufferSize, sizeof(CAN_FRAME));
+
     if (!CAN_WatchDog_Builtin_handler) {
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
         std::ostringstream canWatchDogTaskNameStream;
@@ -421,11 +425,6 @@ void ESP32CAN::enable()
     }
 #endif
 
-    ESP_LOGI(TAG, "Creating queues");
-
-    callbackQueue = xQueueCreate(16, sizeof(CAN_FRAME));
-    rx_queue = xQueueCreate(rxBufferSize, sizeof(CAN_FRAME));
-
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
     std::ostringstream canHandlerTaskNameStream;
     std::ostringstream canLowLevelTaskNameStream;
@@ -497,12 +496,6 @@ void ESP32CAN::disable()
             {
                 vTaskDelete(task);
                 task = NULL;
-            }
-        }
-
-        for (auto queue : {rx_queue, callbackQueue}) {
-            if (queue) {
-                vQueueDelete(queue);
             }
         }
 

--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -582,6 +582,7 @@ bool ESP32CAN::sendFrame(CAN_FRAME& txFrame)
     __TX_frame.extd = txFrame.extended;
     __TX_frame.self = 0;
     __TX_frame.ss = 0;
+    __TX_frame.dlc_non_comp = 0;
     for (int i = 0; i < 8; i++) __TX_frame.data[i] = txFrame.data.byte[i];
 
     //don't wait long if the queue was full. The end user code shouldn't be sending faster

--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -160,24 +160,13 @@ void ESP32CAN::task_CAN( void *pvParameters )
     ESP32CAN* espCan = (ESP32CAN*)pvParameters;
     CAN_FRAME rxFrame;
 
-    //delay a bit upon initial start up
-    vTaskDelay(pdMS_TO_TICKS(100));
-
     while (1)
     {
-        if (uxQueueMessagesWaiting(espCan->callbackQueue)) {
-            //receive next CAN frame from queue and fire off the callback
-            if(xQueueReceive(espCan->callbackQueue, &rxFrame, portMAX_DELAY) == pdTRUE)
-            {
-                espCan->sendCallback(&rxFrame);
-            }
+        //receive next CAN frame from queue and fire off the callback
+        if(xQueueReceive(espCan->callbackQueue, &rxFrame, portMAX_DELAY) == pdTRUE)
+        {
+            espCan->sendCallback(&rxFrame);
         }
-        else vTaskDelay(pdMS_TO_TICKS(4)); //if you don't delay here it will slow down the whole system. Need some delay.
-
-//probably don't need this extra delay. Test and find out.
-#if defined(CONFIG_FREERTOS_UNICORE)
-    vTaskDelay(pdMS_TO_TICKS(6)); 
-#endif
     }
 
     vTaskDelete(NULL);

--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -110,7 +110,7 @@ void ESP32CAN::CAN_WatchDog_Builtin( void *pvParameters )
 #endif
                 if (result != ESP_OK)
                 {
-                    printf("Could not initiate bus recovery!\n");
+                    ESP_LOGE(espCan->TAG, "Could not initiate bus recovery, result = %d!", result);
                 }
             }
         }
@@ -294,11 +294,11 @@ uint32_t ESP32CAN::init(uint32_t ul_baudrate)
 #endif
         if (result == ESP_OK)
         {
-            printf("Alerts reconfigured\n");
+            ESP_LOGI(TAG, "Alerts reconfigured");
         }
         else
         {
-            printf("Failed to reconfigure alerts");
+            ESP_LOGE(TAG, "Failed to reconfigure alerts result = %d", result);
         }
     }
     //this task implements our better filtering on top of the TWAI library. Accept all frames then filter in here VVVVV
@@ -381,7 +381,7 @@ uint32_t ESP32CAN::set_baudrate(uint32_t ul_baudrate)
         }
         idx++;
     }
-    printf("Could not find a valid bit timing! You will need to add your desired speed to the library!\n");
+    ESP_LOGW(TAG, "Could not find a valid bit timing! You will need to add your desired speed to the library!");
     return 0;
 }
 
@@ -421,7 +421,7 @@ void ESP32CAN::enable()
     }
 #endif
 
-    printf("Creating queues\n");
+    ESP_LOGI(TAG, "Creating queues");
 
     callbackQueue = xQueueCreate(16, sizeof(CAN_FRAME));
     rx_queue = xQueueCreate(rxBufferSize, sizeof(CAN_FRAME));
@@ -438,11 +438,11 @@ void ESP32CAN::enable()
     const char* canLowLevelTaskName = "CAN_LORX_CAN";
 #endif
 
-    printf("Starting can handler task\n");
+    ESP_LOGI(TAG, "Starting can handler task %s", canHandlerTaskName);
     xTaskCreate(ESP32CAN::task_CAN, canHandlerTaskName, 8192, this, 15, &task_CAN_handler);
 
 #if defined(CONFIG_FREERTOS_UNICORE)
-    printf("Starting low level RX task\n");
+    ESP_LOGI(TAG, "Starting low level RX task %s", canLowLevelTaskName);
     xTaskCreate(ESP32CAN::task_LowLevelRX, canLowLevelTaskName, 4096, this, 19, &task_LowLevelRX_handler);
 #else
     //this next task implements our better filtering on top of the TWAI library. Accept all frames then filter in here VVVVV

--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -305,20 +305,7 @@ uint32_t ESP32CAN::init(uint32_t ul_baudrate)
             ESP_LOGE(TAG, "Failed to reconfigure alerts result = %d", result);
         }
     }
-    //this task implements our better filtering on top of the TWAI library. Accept all frames then filter in here VVVVV
-#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
-    std::ostringstream canLowLevelTaskNameStream;
-    canLowLevelTaskNameStream << "CAN_LORX_CAN" << twai_general_cfg.controller_id;
-    const char* canLowLevelTaskName = canLowLevelTaskNameStream.str().c_str();
-#else
-    const char* canLowLevelTaskName = "CAN_LORX_CAN0";
-#endif
 
-#if defined(CONFIG_FREERTOS_UNICORE)
-    xTaskCreate(ESP32CAN::task_LowLevelRX, canLowLevelTaskName, 4096, this, 19, NULL);
-#else
-    xTaskCreatePinnedToCore(ESP32CAN::task_LowLevelRX, canLowLevelTaskName, 4096, this, 19, NULL, 1);
-#endif
     ESP_LOGD(TAG, "init(): readyForTraffic = true");
     readyForTraffic = true;
     return ul_baudrate;

--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -608,15 +608,12 @@ uint32_t ESP32CAN::get_rx_buff(CAN_FRAME &msg)
 {
     CAN_FRAME frame;
     //receive next CAN frame from queue
-    if (uxQueueMessagesWaiting(rx_queue)) {
-        if(xQueueReceive(rx_queue, &frame, 0) == pdTRUE)
-        {
-            msg = frame; //do a copy in the case that the receive worked
-            return true;
-        }
-        else
-            return false;
+    if(xQueueReceive(rx_queue, &frame, 0) == pdTRUE)
+    {
+        msg = frame; //do a copy in the case that the receive worked
+        return true;
     }
-    return false; //otherwise we leave the msg variable alone and just return false
+    else
+        return false;
 }
 

--- a/src/esp32_can_builtin.cpp
+++ b/src/esp32_can_builtin.cpp
@@ -580,6 +580,8 @@ bool ESP32CAN::sendFrame(CAN_FRAME& txFrame)
     __TX_frame.data_length_code = txFrame.length;
     __TX_frame.rtr = txFrame.rtr;
     __TX_frame.extd = txFrame.extended;
+    __TX_frame.self = 0;
+    __TX_frame.ss = 0;
     for (int i = 0; i < 8; i++) __TX_frame.data[i] = txFrame.data.byte[i];
 
     //don't wait long if the queue was full. The end user code shouldn't be sending faster

--- a/src/esp32_can_builtin.h
+++ b/src/esp32_can_builtin.h
@@ -114,6 +114,7 @@ protected:
   TaskHandle_t task_LowLevelRX_handler = NULL;
 
 private:
+  char TAG[10] = {0};
   // Pin variables
   ESP32_FILTER filters[BI_NUM_FILTERS];
   int rxBufferSize;


### PR DESCRIPTION
- During our tests with recorded data from a cars CAN  bus (500kBit/s) we had a loss of over 90% while forwarding from CAN0 to CAN1.
- The main reason are were the sleeps in `task_CAN()`
- To overcome the sleeps without stability issues, we moved the creation of the queues to `_init()`
- The creation  and deletion if the tasks ist still active, as introduced in the fix to https://github.com/collin80/esp32_can/issues/48
- In addition, the extra init of `task_LowLevelRX()` was cleaned up